### PR TITLE
RESOURCES: add raw syntax files

### DIFF
--- a/builtins/regular/functions.csv
+++ b/builtins/regular/functions.csv
@@ -1,0 +1,11 @@
+Name,Argument type,Result type,Function
+ABS,x: numeric type,type of x,absolute value
+ASR,"x, n: INTEGER",INTEGER,"signed shift right, x DIV 2"
+CHR,x: INTEGER,CHAR,character with ordinal number x
+FLOOR,x: REAL,INTEGER,round down
+FLT,x: INTEGER,REAL,identity
+LEN,v: array,INTEGER,the length of v
+LSL,"x, n: INTEGER",INTEGER,"logical shift left, x * 2^n"
+ODD,x: INTEGER,BOOLEAN,x MOD 2 = 1
+ORD,"x: CHAR, BOOLEAN, SET",INTEGER,ordinal number of x
+ROR,"x, n: INTEGER",INTEGER,x rotated right by n bits

--- a/builtins/regular/procedures.csv
+++ b/builtins/regular/procedures.csv
@@ -1,0 +1,11 @@
+Name,Argument type,Function
+ASSERT,b: BOOLEAN,abort if ~b
+DEC,v: INTEGER,v := v - 1
+DEC,"v, n: INTEGER",v := v - n
+EXCL,v: SET; x: INTEGER,v := v - {x}
+INC,v: INTEGER,v := v + 1
+INC,"v, n: INTEGER",v := v + n
+INCL,v: SET; x: INTEGER,v := v + {x}
+NEW,v: pointer type,allocate v^
+PACK,x: REAL; n: INTEGER,pack x and n into x
+UNPK,x: REAL; n: INTEGER,unpack x into x and n

--- a/builtins/system/functions.csv
+++ b/builtins/system/functions.csv
@@ -1,0 +1,9 @@
+Name,Argument type,Result type,Function
+SYSTEM.ADC,"m, n: INTEGER",INTEGER,add with carry C
+SYSTEM.ADR,v: any,INTEGER,address of variable v
+SYSTEM.BIT,"a, n: INTEGER",BOOLEAN,bit n of mem[a]
+SYSTEM.COND,n: INTEGER,BOOLEAN,IF Cond(n) THEN ...
+SYSTEM.SBC,"m, n: INTEGER",INTEGER,subtract with carry C
+SYSTEM.SIZE,T: any type,INTEGER,size in bytes
+SYSTEM.UML,"m, n: INTEGER",INTEGER,unsigned multiplication
+SYSTEM.VAL,"T, n: scalar",T,identity

--- a/builtins/system/procedures.csv
+++ b/builtins/system/procedures.csv
@@ -1,0 +1,5 @@
+Name,Argument type,Function
+SYSTEM.COPY,"src, dst, n: INTEGER",copy n consecutive words from src to dst
+SYSTEM.GET,a: INTEGER; v: any basic type,v := mem[a]
+SYSTEM.LED,n: INTEGER,display n on LEDs
+SYSTEM.PUT,a: INTEGER; x: any basic type,mem[a] := x

--- a/rules.txt
+++ b/rules.txt
@@ -1,0 +1,61 @@
+ActualParameters = "(" [ExpList] ")"
+AddOperator = "+" | "-" | OR
+ArrayType = ARRAY length {"," length} OF type
+BaseType = qualident
+CaseLabelList = LabelRange {"," LabelRange}
+CaseStatement = CASE expression OF case {"|" case} END
+ConstDeclaration = identdef "=" ConstExpression
+ConstExpression = expression
+DeclarationSequence = [CONST {ConstDeclaration ";"}] [TYPE {TypeDeclaration ";"}] [VAR {VariableDeclaration ";"}] {ProcedureDeclaration ";"}
+ExpList = expression {"," expression}
+FPSection = [VAR] ident {"," ident} ":" FormalType
+FieldList = IdentList ":" type
+FieldListSequence = FieldList {";" FieldList}
+ForStatement = FOR ident ":=" expression TO expression [BY ConstExpression] DO StatementSequence END
+FormalParameters = "(" [FPSection {";" FPSection}] ")" [":" qualident]
+FormalType = {ARRAY OF} qualident
+IdentList = identdef {"," identdef}
+IfStatement = IF expression THEN StatementSequence {ELSIF expression THEN StatementSequence} [ELSE StatementSequence] END
+ImportList = IMPORT import {"," import} ";"
+LabelRange = label [".." label]
+MulOperator = "*" | "/" | DIV | MOD | "&"
+PointerType = POINTER TO type
+ProcedureBody = DeclarationSequence [BEGIN StatementSequence] [RETURN expression] END
+ProcedureCall = designator [ActualParameters]
+ProcedureDeclaration = ProcedureHeading ";" ProcedureBody ident
+ProcedureHeading = PROCEDURE identdef [FormalParameters]
+ProcedureType = PROCEDURE [FormalParameters]
+RecordType = RECORD ["(" BaseType ")"] [FieldListSequence] END
+RepeatStatement = REPEAT StatementSequence UNTIL expression
+ScaleFactor = "E" ["+" | "-"] digit {digit}
+SimpleExpression = ["+" | "-"] term {AddOperator term}
+StatementSequence = statement {";" statement}
+TypeDeclaration = identdef "=" type
+VariableDeclaration = IdentList ":" type
+WhileStatement = WHILE expression DO StatementSequence {ELSIF expression DO StatementSequence} END
+assignment = designator ":=" expression
+case = [CaseLabelList ":" StatementSequence]
+designator = qualident {selector}
+digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+element = expression [".." expression]
+expression = SimpleExpression [relation SimpleExpression]
+factor = number | string | NIL | TRUE | FALSE | set | designator [ActualParameters] | "(" expression ")" | "~" factor
+hexDigit = digit | "A" | "B" | "C" | "D" | "E" | "F"
+ident = letter {letter | digit}
+identdef = ident ["*"]
+import = ident [":=" ident]
+integer = digit {digit} | digit {hexDigit} "H"
+label = integer | string | qualident
+length = ConstExpression
+letter = "A" | "B" | ... | "Z" | "a" | "b" | ... | "z"
+module = MODULE ident ";" [ImportList] DeclarationSequence [BEGIN StatementSequence] END ident "."
+number = integer | real
+qualident = [ident "."] ident
+real = digit {digit} "." {digit} [ScaleFactor]
+relation = "=" | "#" | "<" | "<=" | ">" | ">=" | IN | IS
+selector = "." ident | "[" ExpList "]" | "^" | "(" qualident ")"
+set = "{" [element {"," element}] "}"
+statement = [assignment | ProcedureCall | IfStatement | CaseStatement | WhileStatement | RepeatStatement | ForStatement]
+string = """ {character} """ | digit {hexDigit} "X"
+term = factor {MulOperator factor}
+type = qualident | ArrayType | RecordType | PointerType | ProcedureType


### PR DESCRIPTION
This PR adds the raw:
  - rule file in `rules.txt`
  - built-in procedure files in `builtins/regular/functions.csv`, `builtins/regular/procedures.csv`, `builtins/system/functions.csv` and `builtins/system/procedures.csv`

as defined in the [Oberon report](https://people.inf.ethz.ch/wirth/Oberon/Oberon07.Report.pdf).