### PR TITLE
FIX: put the duplicate procedures in one single entry

### DIFF
--- a/res/builtins/regular/procedures.csv
+++ b/res/builtins/regular/procedures.csv
@@ -1,10 +1,8 @@
 Name,Argument type,Function
 ASSERT,b: BOOLEAN,abort if ~b
-DEC,v: INTEGER,v := v - 1
-DEC,"v, n: INTEGER",v := v - n
+DEC,"v: INTEGER\nv, n: INTEGER",v:= v - 1\nv := v - n
 EXCL,v: SET; x: INTEGER,v := v - {x}
-INC,v: INTEGER,v := v + 1
-INC,"v, n: INTEGER",v := v + n
+INC,"v: INTEGER\nv, n: INTEGER",v:= v + 1\nv := v + n
 INCL,v: SET; x: INTEGER,v := v + {x}
 NEW,v: pointer type,allocate v^
 PACK,x: REAL; n: INTEGER,pack x and n into x


### PR DESCRIPTION
There are two built-in procedures with overloaded signatures:
- `INC` :point_right: `INC(v: INTEGER);` and `INC(v, n: INTEGER);`
- `DEC` :point_right: `DEC(v: INTEGER);` and `DEC(v, n: INTEGER);`

This PR merges the two almost duplicates lines in the built-in `CSV` definitions, with a `\n` in between.